### PR TITLE
fix Foundry VTT spacing in description

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "id": "size-matters",
   "title": "Size Matters",
-  "description": "A customizable grid highlighting tool for FoundryVTT that works with hex and square grids",
+  "description": "A customizable grid highlighting tool for Foundry VTT that works with hex and square grids",
   "authors": [
     {
       "name": "Boifubá",


### PR DESCRIPTION
## Summary
- fix typo in module description referencing Foundry VTT

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897853808e0832c88beba04a50e28eb